### PR TITLE
Feat/#6 champion rotation

### DIFF
--- a/src/app/TQProvider.tsx
+++ b/src/app/TQProvider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const Provider = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+};
+
+export default Provider;

--- a/src/app/api/rotation/route.ts
+++ b/src/app/api/rotation/route.ts
@@ -1,0 +1,27 @@
+import { ROTATION_CHAMPION_URL } from '@/constants/constants';
+import { ChampionRotation } from '@/types/ChampionRotation';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const res = await fetch(ROTATION_CHAMPION_URL, {
+      method: 'GET',
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
+        'Accept-Language': 'ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7',
+        'Accept-Charset': 'application/x-www-form-urlencoded; charset=UTF-8',
+        Origin: 'https://developer.riotgames.com',
+        'X-Riot-Token': process.env.NEXT_PUBLIC_RIOT_API_KEY || '',
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`로테이션 API 호출 실패: ${res.status}`);
+    }
+    const data: ChampionRotation = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: error }, { status: 500 });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,32 +3,35 @@ import localFont from 'next/font/local';
 import '../styles/globals.css';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
+import Provider from './TQProvider';
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
   display: 'swap',
   weight: '100 900',
-  variable: '--font-pretendard'
+  variable: '--font-pretendard',
 });
 
 export const metadata: Metadata = {
   title: 'LoLLoL Next.js App',
-  description: 'Riot Games API를 활용한 LoL 정보 웹 앱입니다.'
+  description: 'Riot Games API를 활용한 LoL 정보 웹 앱입니다.',
 };
 
 export default function RootLayout({
-  children
+  children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
     <html lang="ko" className={pretendard.variable}>
       <body className={`${pretendard.variable} font-pretendard`}>
-        <Header />
-        <main className="flex flex-grow items-center w-full p-8 max-w-[1200px] mx-auto relative min-h-[calc(100vh-140px)] box-border text-center justify-center">
-          {children}
-        </main>
-        <Footer />
+        <Provider>
+          <Header />
+          <main className="relative mx-auto box-border flex min-h-[calc(100vh-140px)] w-full max-w-[1200px] flex-grow items-center justify-center p-8 text-center">
+            {children}
+          </main>
+          <Footer />
+        </Provider>
       </body>
     </html>
   );

--- a/src/app/rotation/page.tsx
+++ b/src/app/rotation/page.tsx
@@ -1,5 +1,15 @@
+import RotationChampionList from '@/components/RotationChampionList';
+
 const RotationPage = () => {
-  return <div>RotationPage</div>;
+  return (
+    <section>
+      <article className="flex flex-col p-4">
+        <h2 className="font-pretendard text-4xl font-bold">챔피언 로테이션</h2>
+        <p className="mt-4 text-gray-400">이번주 무료로 플레이 할 수 있어요!</p>
+        <RotationChampionList />
+      </article>
+    </section>
+  );
 };
 
 export default RotationPage;

--- a/src/components/ChampionCard.tsx
+++ b/src/components/ChampionCard.tsx
@@ -1,4 +1,4 @@
-import { championSquareImgUrl} from '@/constants/constants';
+import { championSquareImgUrl } from '@/constants/constants';
 import { Champion } from '@/types/Champion';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -11,16 +11,16 @@ const ChampionCard = ({ champion }: ChampionCardProps) => {
   const SQUARE_IMAGE_URL = championSquareImgUrl(champion.version);
 
   return (
-    <li className="p-4 border rounded-lg border-violet-300">
-      <Link href={`/champions/${champion.id}`} className='flex flex-col items-start '>
+    <li className="rounded-lg border border-violet-300 p-4">
+      <Link href={`/champions/${champion.id}`} className="flex flex-col items-start">
         <Image
           src={`${SQUARE_IMAGE_URL}/${champion.id}.png`}
-          alt={`${champion.name} 이미지`}
-          width={200}
-          height={200}
-          className='mx-auto'
+          alt={champion.name}
+          width={150}
+          height={150}
+          className="mx-auto"
         />
-        <h2 className="mt-2 text-xl font-semibold text-violet-500">{champion.name}</h2>
+        <h3 className="mt-2 text-xl font-semibold text-violet-500">{champion.name}</h3>
         <p className="text-gray-400">{champion.title}</p>
       </Link>
     </li>

--- a/src/components/RotationChampionList.tsx
+++ b/src/components/RotationChampionList.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Champion } from '@/types/Champion';
+import { getChampionRotation } from '@/utils/riotApi';
+import { fetchChampionList } from '@/utils/serverApi';
+import { useQuery } from '@tanstack/react-query';
+import ChampionCard from './ChampionCard';
+
+const RotationChampionList = () => {
+  const {
+    data: rotationData,
+    isPending: rotationPending,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['rotationKeyList'],
+    queryFn: getChampionRotation,
+  });
+
+  const { data: championsData, isPending: championPending } = useQuery({
+    queryKey: ['championList'],
+    queryFn: fetchChampionList,
+  });
+
+  if (rotationPending || championPending) return <div>불러오는 중...</div>;
+  if (isError) return <div>에러 발생: {error.message}</div>;
+  if (!rotationData || !championsData) return <div>데이터가 없습니다</div>;
+
+  const championMap = championsData
+    ? new Map(Object.entries(championsData).map(([, champion]) => [champion.key, champion]))
+    : new Map<string, Champion>();
+
+  const rotationChampionList = rotationData.freeChampionIds
+    .map((rotationId: number) => championMap.get(String(rotationId)))
+    .filter((champion) => champion !== undefined) as Champion[];
+
+  return (
+    <ul className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {rotationChampionList?.map((champion) => <ChampionCard key={champion.key} champion={champion} />)}
+    </ul>
+  );
+};
+
+export default RotationChampionList;

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,6 +1,7 @@
 export const LOL_API_URL = 'https://ddragon.leagueoflegends.com';
 export const LOADING_IMG_URL = `${LOL_API_URL}/cdn/img/champion/loading`;
 export const SPLASH_IMG_URL = `${LOL_API_URL}/cdn/img/champion/splash`;
+export const ROTATION_CHAMPION_URL = 'https://kr.api.riotgames.com/lol/platform/v3/champion-rotations';
 
 export const DEFAULT_LANGUAGE = 'ko_KR';
 

--- a/src/types/ChampionRotation.ts
+++ b/src/types/ChampionRotation.ts
@@ -1,0 +1,5 @@
+export type ChampionRotation = {
+  freeChampionIds: number[];
+  freeChampionIdsForNewPlayers: number[];
+  maxNewPlayerLevel: number;
+};

--- a/src/utils/riotApi.ts
+++ b/src/utils/riotApi.ts
@@ -1,0 +1,11 @@
+import { ChampionRotation } from '@/types/ChampionRotation';
+
+// 챔피언 로테이션 목록 가져오기
+export const getChampionRotation = async (): Promise<ChampionRotation> => {
+  const res = await fetch('/api/rotation');
+  if (!res.ok) {
+    throw new Error(`Rotation API 요청 실패: ${res.status}`);
+  }
+  const data = await res.json();
+  return data;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #6 

<br>

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- riot API Key 발급 후 무료 챔피언 리스트 id와 챔피언목록의 Key를 비교 하여 로테이션 챔피언 리스트 구현

<br>

## 🖼 스크린샷

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ff8da452-badf-4e38-bdcb-654c7d1f76b2" />

<br>

## 💬리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ✳️ 라우트 핸들러스 작업 재확인 하기, CSR랜더링이나 챔피언카드 컴포넌트 재활용으로 <서버><클라><서버> 구조로 되어 있음